### PR TITLE
feat: more lax queries in twig&js that target any string

### DIFF
--- a/lua/tailwind-sorter/tsutil.lua
+++ b/lua/tailwind-sorter/tsutil.lua
@@ -77,22 +77,26 @@ M.get_query_matches = function(buf)
         end
 
         for pattern, match, _ in query:iter_matches(tree:root(), buf, 0, -1) do
-          for id, node in pairs(match) do
-            if query.captures[id] == 'tailwind' then
-              local res = { node = node, buf = buf }
+          if match then
+            for id, node in pairs(match) do
+              if query.captures[id] == 'tailwind' then
+                local res = { node = node, buf = buf }
 
-              for _, pred in pairs(query.info.patterns[pattern]) do
-                if pred[2] == id and pred[1] == 'offset!' then
-                  res.offset = {
-                    start_row = tonumber(pred[3]),
-                    start_col = tonumber(pred[4]),
-                    end_row = tonumber(pred[5]),
-                    end_col = tonumber(pred[6]),
-                  }
+                if query.info.patterns[pattern] then
+                  for _, pred in pairs(query.info.patterns[pattern]) do
+                    if pred[2] == id and pred[1] == 'offset!' then
+                      res.offset = {
+                        start_row = tonumber(pred[3]),
+                        start_col = tonumber(pred[4]),
+                        end_row = tonumber(pred[5]),
+                        end_col = tonumber(pred[6]),
+                      }
+                    end
+                  end
                 end
-              end
 
-              table.insert(matches, res)
+                table.insert(matches, res)
+              end
             end
           end
         end

--- a/queries/javascript/tailwind.scm
+++ b/queries/javascript/tailwind.scm
@@ -1,5 +1,1 @@
-(jsx_attribute
-  (property_identifier) @_name
-    (#eq? @_name "className")
-  (string
-    (string_fragment) @tailwind))
+(string_fragment) @tailwind

--- a/queries/twig/tailwind.scm
+++ b/queries/twig/tailwind.scm
@@ -1,0 +1,2 @@
+((string) @tailwind
+  (#offset! @tailwind 0 2 -1 -2))

--- a/tests/fixtures/automatic/test.jsx
+++ b/tests/fixtures/automatic/test.jsx
@@ -1,4 +1,8 @@
+const txt = true ? 'flex-grow flex' : 'gap-3 grid';
+
 const element = <div className="flex-grow flex w-full"></div>;
 /**  Basic JSX
+const txt = true ? 'flex flex-grow' : 'grid gap-3';
+
 const element = <div className="flex w-full flex-grow"></div>;
 */

--- a/tests/fixtures/automatic/test.twig
+++ b/tests/fixtures/automatic/test.twig
@@ -1,4 +1,6 @@
+{% set classes = 'flex-grow test flex grid gap-3' %}
 <div class="grid gap-3 text-blue-400 test"></div>
 <!-- test basic twig
+{% set classes = 'test flex grid flex-grow gap-3' %}
 <div class="test grid gap-3 text-blue-400"></div>
 -->


### PR DESCRIPTION
After some feedback, found that just targeting 'className' or 'class' attributes was to strict. Lots of classes are put in variables or conditionally applied.

This PR alters twig&js/jsx to target any string in its variables.

The formatter only sorts classes it knows about, so this should not create false positives.