### PR TITLE
feat(astro): add tailwind query

### DIFF
--- a/queries/astro/tailwind.scm
+++ b/queries/astro/tailwind.scm
@@ -1,0 +1,1 @@
+; inherits: html


### PR DESCRIPTION
Add support for [astro](https://astro.build/). The format of `.astro` file is almost the same as an `.html` file with some typescript at the top ([reference](https://github.com/virchau13/tree-sitter-astro#specification)), so it suffices to reuse the `tailwind.scm` from the html folder. Tested locally and it works great!