### PR TITLE
fix: php parser uses strint_content now

### DIFF
--- a/queries/php/tailwind.scm
+++ b/queries/php/tailwind.scm
@@ -1,1 +1,1 @@
-(string_value) @tailwind
+(string_content) @tailwind


### PR DESCRIPTION
There was a change in php treesitter parser, and now string content is named `string_content`` and not `string_value`.