### PR TITLE
Added an option to trim extra spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ require('tailwind-sorter').setup({
   on_save_enabled = false, -- If `true`, automatically enables on save sorting.
   on_save_pattern = { '*.html', '*.js', '*.jsx', '*.tsx', '*.twig', '*.hbs', '*.php', '*.heex', '*.astro' }, -- The file patterns to watch and sort.
   node_path = 'node',
+  trim_spaces = false, -- If `true`, trim any extra spaces after sorting.
 })
 ```
 

--- a/lua/tailwind-sorter/config.lua
+++ b/lua/tailwind-sorter/config.lua
@@ -6,6 +6,7 @@ local M = {
     on_save_enabled = false,
     on_save_pattern = { '*.html', '*.js', '*.jsx', '*.tsx', '*.twig', '*.hbs', '*.php', '*.heex', '*.astro', '*.css', '*.templ' },
     node_path = 'node',
+    trim_spaces = false,
   },
 }
 

--- a/lua/tailwind-sorter/init.lua
+++ b/lua/tailwind-sorter/init.lua
@@ -97,6 +97,13 @@ M.sort = function(buf, extra_cfg)
 
   local out = vim.json.decode(result[1])
 
+  -- Optionally trim extra spaces
+  if cfg:get().trim_spaces then
+    for i, class_string in ipairs(out) do
+      out[i] = class_string:gsub("^%s*(.-)%s*$", "%1"):gsub("%s+", " ")
+    end
+  end
+
   -- Iterate the replacements in reverse and set them in the buffer.
   for i = #out, 1, -1 do
     sorted_cache.put(out[i])


### PR DESCRIPTION
As requested in issue https://github.com/laytan/tailwind-sorter.nvim/issues/106

It's easy to accidentally leave an extra space here and there when writing tailwind. I added a small option to trim this extra space: `trim_spaces` (off by default).

For example:
`"  text-slate-500   font-semibold  text-lg  "`

Becomes:
`"text-lg font-semibold text-slate-500"`